### PR TITLE
Storage get count

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ List of commands this console current supports:
 * `EOF` - exits console 
 * `quit` - exits console
 * `<emptyline>` - overwrites default emptyline method and does nothing
-* `create` - Creates a new instance of`BaseModel`, saves it (to the JSON file) and prints the id
+* `create` - Creates a new instance of`BaseModel`, saves it (to the JSON file) and prints the id in the case of db storage instances need to instantiated with the non nullable values example `create State name="Texas"` or `create State name="New_York"` in case of a string value that has space you need to use underscore instead of space and in apostrophies
 * `destroy` - Deletes an instance based on the class name and id (save the change into the JSON file). 
 * `show` - Prints the string representation of an instance based on the class name and id.
 * `all` - Prints all string representation of all instances based or not on the class name. 

--- a/console.py
+++ b/console.py
@@ -46,10 +46,10 @@ class HBNBCommand(cmd.Cmd):
                 else:
                     try:
                         value = int(value)
-                    except:
+                    except Exception:
                         try:
                             value = float(value)
-                        except:
+                        except Exception:
                             continue
                 new_dict[key] = value
         return new_dict
@@ -140,12 +140,12 @@ class HBNBCommand(cmd.Cmd):
                                 if args[2] in integers:
                                     try:
                                         args[3] = int(args[3])
-                                    except:
+                                    except Exception:
                                         args[3] = 0
                                 elif args[2] in floats:
                                     try:
                                         args[3] = float(args[3])
-                                    except:
+                                    except Exception:
                                         args[3] = 0.0
                             setattr(models.storage.all()[k], args[2], args[3])
                             models.storage.all()[k].save()
@@ -159,6 +159,7 @@ class HBNBCommand(cmd.Cmd):
                 print("** instance id missing **")
         else:
             print("** class doesn't exist **")
+
 
 if __name__ == '__main__':
     HBNBCommand().cmdloop()

--- a/file.json
+++ b/file.json
@@ -1,0 +1,1 @@
+{"State.e8ba02c0-a3db-4bac-954a-efe256c06ab9": {"id": "e8ba02c0-a3db-4bac-954a-efe256c06ab9", "created_at": "2024-02-01T13:13:50.780077", "updated_at": "2024-02-01T13:13:50.780424", "__class__": "State"}}

--- a/file.json
+++ b/file.json
@@ -1,1 +1,0 @@
-{"State.e8ba02c0-a3db-4bac-954a-efe256c06ab9": {"id": "e8ba02c0-a3db-4bac-954a-efe256c06ab9", "created_at": "2024-02-01T13:13:50.780077", "updated_at": "2024-02-01T13:13:50.780424", "__class__": "State"}}

--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -74,7 +74,7 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
-    
+
     def get(self, cls, id):
         """
         Returns the object based on the class and its ID,
@@ -82,3 +82,11 @@ class DBStorage:
         """
         objects = models.storage.all(cls)
         return objects.get("{}.{}".format(cls.__name__, id))
+
+    def count(self, cls=None):
+        """
+        Returns the number of objects in storage matching the given class,
+        or the total number of objects if no class is passed
+        """
+        objects = models.storage.all(cls)
+        return len(objects)

--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -74,3 +74,11 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
+    
+    def get(self, cls, id):
+        """
+        Returns the object based on the class and its ID,
+        or None if not found
+        """
+        objects = models.storage.all(cls)
+        return objects.get("{}.{}".format(cls.__name__, id))

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -55,7 +55,7 @@ class FileStorage:
                 jo = json.load(f)
             for key in jo:
                 self.__objects[key] = classes[jo[key]["__class__"]](**jo[key])
-        except:
+        except Exception:
             pass
 
     def delete(self, obj=None):
@@ -68,7 +68,7 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
-    
+
     def get(self, cls, id):
         """
         Returns the object based on the class and its ID,
@@ -78,3 +78,13 @@ class FileStorage:
 
         objects = storage.all(cls)
         return objects.get("{}.{}".format(cls.__name__, id))
+
+    def count(self, cls=None):
+        """
+        Returns the number of objects in storage matching the given class.
+        If no class is passed, returns the number of all objects in storage.
+        """
+        from models import storage
+
+        objects = storage.all(cls)
+        return len(objects)

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -68,3 +68,13 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+    
+    def get(self, cls, id):
+        """
+        Returns the object based on the class and its ID,
+        or None if not found
+        """
+        from models import storage
+
+        objects = storage.all(cls)
+        return objects.get("{}.{}".format(cls.__name__, id))

--- a/models/user.py
+++ b/models/user.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 """ holds class User"""
+import base64
+import bcrypt
 import models
 from models.base_model import BaseModel, Base
 from os import getenv
@@ -26,4 +28,10 @@ class User(BaseModel, Base):
 
     def __init__(self, *args, **kwargs):
         """initializes user"""
+        if "password" in kwargs:
+            password = kwargs["password"]
+            salt = bcrypt.gensalt()
+            password = bcrypt.hashpw(password.encode('utf-8'), salt)
+            password = base64.b64encode(password).decode('utf-8')
+            kwargs["password"] = password
         super().__init__(*args, **kwargs)

--- a/test_bench.py
+++ b/test_bench.py
@@ -1,0 +1,5 @@
+import models
+
+from models.state import State
+
+print(models.storage.get(State, ""))

--- a/test_bench.py
+++ b/test_bench.py
@@ -1,5 +1,6 @@
 import models
 
 from models.state import State
+from models.user import User
 
-print(models.storage.get(State, ""))
+print(models.storage.count())

--- a/tests/test_models/test_base_model.py
+++ b/tests/test_models/test_base_model.py
@@ -82,14 +82,14 @@ class TestBaseModel(unittest.TestCase):
         """Test that two BaseModel instances have different datetime objects
         and that upon creation have identical updated_at and created_at
         value."""
-        tic = datetime.now()
+        tic = datetime.utcnow()
         inst1 = BaseModel()
-        toc = datetime.now()
+        toc = datetime.utcnow()
         self.assertTrue(tic <= inst1.created_at <= toc)
         time.sleep(1e-4)
-        tic = datetime.now()
+        tic = datetime.utcnow()
         inst2 = BaseModel()
-        toc = datetime.now()
+        toc = datetime.utcnow()
         self.assertTrue(tic <= inst2.created_at <= toc)
         self.assertEqual(inst1.created_at, inst1.updated_at)
         self.assertEqual(inst2.created_at, inst2.updated_at)

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -86,3 +86,24 @@ class TestFileStorage(unittest.TestCase):
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_save(self):
         """Test that save properly saves objects to file.json"""
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get(self):
+        """Test that get returns the correct object"""
+        new_state = State(name="California")
+        models.storage.new(new_state)
+        models.storage.save()
+        self.assertIs(models.storage.get(State, new_state.id), new_state)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count(self):
+        """Test that count returns the number of objects in storage"""
+        self.assertEqual(models.storage.count(), 0)
+        new_state = State(name="California")
+        models.storage.new(new_state)
+        models.storage.save()
+        self.assertEqual(models.storage.count(), 1)
+        new_state = State(name="Nevada")
+        models.storage.new(new_state)
+        models.storage.save()
+        self.assertEqual(models.storage.count(), 2)

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -113,3 +113,36 @@ class TestFileStorage(unittest.TestCase):
         with open("file.json", "r") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_get(self):
+        """Test get function"""
+        storage = FileStorage()
+        new_state = State(name="California")
+        storage.new(new_state)
+        storage.save()
+        self.assertEqual(storage.get(State, new_state.id), new_state)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_count(self):
+        """Test count function"""
+        storage = FileStorage()
+        self.assertEqual(storage.count(), 0)
+        new_state = State(name="California")
+        storage.new(new_state)
+        storage.save()
+        self.assertEqual(storage.count(), 1)
+        new_state = State(name="Nevada")
+        storage.new(new_state)
+        storage.save()
+        self.assertEqual(storage.count(), 2)
+        storage.delete(new_state)
+        self.assertEqual(storage.count(), 1)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def tearDown(self):
+        """Tear down for FileStorage test"""
+        try:
+            os.remove("file.json")
+        except Exception:
+            pass


### PR DESCRIPTION
- Fixed some PEP8 non-conformance instances
- Added some documentation to help better understand the use of console to create instances
- Added get() and count() for both storage systems
- Added unittests for both those functions
- Added password salt and hashing when stored using bcrypt
- Added tearDown function for fileStorage testing